### PR TITLE
Move test dependencies to [dev-dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ homepage = "https://github.com/cobalt-forge/urlendec"
 repository = "https://github.com/cobalt-forge/urlendec"
 license = "MIT"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 urlencoding = "2.0"
 env_logger = "0.10.0"
 log = "0.4.17"
+
+[dev-dependencies]
 assert_cmd = "2.0.8"
 predicates = "2.1.5"
 assert_fs = "1.0.10"


### PR DESCRIPTION
Less work for cargo install, lower probability for the build to fail. But the real reason for me to do this is that I wanted to throw a copy onto wapm.io, for the occasional [one-off](https://webassembly.sh/?run-command=urlendec%20-s%20%25E2%2581%25BB%255C_%2528%25E3%2581%25A4%2529_%252F%25E2%2581%25BB%20-d) shenanigans. The test-dependencies don't build for `wasm32-wasi`.